### PR TITLE
Fix keyboard input lag in some cases

### DIFF
--- a/include/tray.c
+++ b/include/tray.c
@@ -38,13 +38,12 @@ int UpdateTray() {
   wcsncpy(tray.szTip, (ENABLED() && elevated?l10n.tray_elevated:ENABLED()?l10n.tray_enabled:l10n.tray_disabled), ARRAY_SIZE(tray.szTip));
   tray.hIcon = icon[ENABLED()?1:0];
 
-  // Try until it succeeds, sleep 100 ms between each attempt
-  while (Shell_NotifyIcon((tray_added?NIM_MODIFY:NIM_ADD),&tray) == FALSE) {
-    Sleep(100);
-  }
-  // Success
-  tray_added = 1;
-  return 0;
+  // Try once. If it doesn't succeed, try again when UpdateTray is called.
+  // Keep in mind that this function shouldn't block or else the keyboard hook
+  // will have very poor response time due to event timeouts.
+  int success = Shell_NotifyIcon((tray_added?NIM_MODIFY:NIM_ADD),&tray);
+  tray_added = success ? 1 : tray_added;
+  return success ? 1 : 0;
 }
 
 int RemoveTray() {


### PR DESCRIPTION
Previously, under certain conditions when entering a full screen application, Shell_NotifyIcon would repeatedly fail to add or modify the superf4 icon. When it did, the keyboard event hook would time out causing a large amount of input lag for every keystroke.

This patch works around the issue by attempting to add or modify the icon exactly once to avoid blocking the event loop.
