### PR TITLE
ARM64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,15 +2,19 @@
 # sudo apt-get install gcc-mingw-w64 nsis
 
 if [[ "$1" == "release" ]]; then
-  mkdir -p bin/32 bin/64
+  mkdir -p bin/32 bin/64 bin/arm64
   cp SuperF4.ini bin/32/
   cp SuperF4.ini bin/64/
+  cp SuperF4.ini bin/arm64/
 
   i686-w64-mingw32-windres -o superf4.o include/app.rc
   i686-w64-mingw32-gcc -o bin/32/SuperF4.exe superf4.c superf4.o -mwindows -lshlwapi -lpsapi -O2 -s -fstack-protector-all -static -Wl,--dynamicbase,--nxcompat,--high-entropy-va -Wp,-D_FORTIFY_SOURCE=2
 
   x86_64-w64-mingw32-windres -o superf4.o include/app.rc
   x86_64-w64-mingw32-gcc -o bin/64/SuperF4.exe superf4.c superf4.o -mwindows -lshlwapi -lpsapi -O2 -s -fstack-protector-all -static -Wl,--dynamicbase,--nxcompat,--high-entropy-va -Wp,-D_FORTIFY_SOURCE=2
+
+  aarch64-w64-mingw32-windres -o superf4.o include/app.rc
+  aarch64-w64-mingw32-gcc -o bin/arm64/SuperF4.exe superf4.c superf4.o -mwindows -lshlwapi -lpsapi -O2 -s -fstack-protector-all -static -Wl,--dynamicbase,--nxcompat,--high-entropy-va -Wp,-D_FORTIFY_SOURCE=2
 
   makensis -V2 -Dx64 installer.nsi
 else

--- a/installer.nsi
+++ b/installer.nsi
@@ -147,8 +147,10 @@ Section "" sec_app
 
   ; Install files
   !ifdef x64
-  ${If} ${RunningX64}
+  ${If} ${IsNativeAMD64}
     File "bin\64\${APP_NAME}.exe"
+  ${ElseIf} ${IsNativeARM64}
+    File "bin\arm64\${APP_NAME}.exe"
   ${Else}
     File "bin\32\${APP_NAME}.exe"
   ${EndIf}


### PR DESCRIPTION
I gave Windows 10 on ARM a try on my Raspberry Pi, and decided to try to compile a native binary. The 32-bit binary works fine by the way, and that is what the installer will install as well, so you can definitely use the normal v1.4 for now.

It seems like the mingw-w64 arm64 support is fairly new, so the packages are not available in the Debian or Ubuntu repositories. I don't think I will merge this until this part is easier.

To compile it right now, you can use binaries from https://github.com/mstorsjo/llvm-mingw.

```
# this works on Debian too

wget https://github.com/mstorsjo/llvm-mingw/releases/download/20200325/llvm-mingw-20200325-ubuntu-18.04.tar.xz
tar xJf llvm-mingw-20200325-ubuntu-18.04.tar.xz
export PATH="$HOME/llvm-mingw-20200325-ubuntu-18.04/bin:$PATH"

git clone -b arm64 https://github.com/stefansundin/superf4.git
cd superf4
./build.sh release
```

Download:
- [SuperF4-ARM64-beta.zip](https://github.com/stefansundin/superf4/files/5324389/SuperF4-ARM64-beta.zip)
- [SuperF4-ARM64-beta-installer.zip](https://github.com/stefansundin/superf4/files/5324391/SuperF4-ARM64-beta-installer.zip)

